### PR TITLE
fix: Craft expects package.json to have previous version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
       merge_target:
         description: Target branch to merge into. Uses the default branch as a fallback (optional)
         required: false
-        default: master
+        default: main
 jobs:
   release:
     runs-on: ubuntu-20.04

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry-internal/node-cpu-profiler",
-  "version": "2.0.0",
+  "version": "1.3.3",
   "description": "Binaries for Sentry Node Profiling",
   "repository": "git://github.com/getsentry/sentry-javascript-profiling-node-binaries.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/profiling-node",


### PR DESCRIPTION
Release publishing failed because the package looked like v2.0.0 had already been released!