### PR TITLE
fix: Do not publish to release registry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,7 +3,4 @@ changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   - name: npm
-  - name: registry
-    sdks:
-      npm:@sentry-internal/node-cpu-profiler:
   - name: github


### PR DESCRIPTION
It looks like `@sentry-internal` packages are not published to the release registry.