### PR TITLE
ci: Build Linux in container for wider glibc support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Setup Musl
         if: contains(matrix.container, 'alpine')
         run: |
-          curl -OL https://musl.cc.timfish.dev/aarch64-linux-musl-cross.tgz
+          curl -OL https://storage.googleapis.com/sentry-dev-infra-build-assets/aarch64-linux-musl-cross.tgz
           tar -xzvf aarch64-linux-musl-cross.tgz
           $(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc --version
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,19 @@ jobs:
         include:
           # x64 glibc
           - os: ubuntu-22.04
+            container: ghcr.io/getsentry/sentry-test-ubuntu-20.04-amd64:0dd255f3d41d013c1db4c4e08ffd22ee7959c3cc
             node: 18
             binary: linux-x64-glibc-108
           - os: ubuntu-22.04
+            container: ghcr.io/getsentry/sentry-test-ubuntu-20.04-amd64:0dd255f3d41d013c1db4c4e08ffd22ee7959c3cc
             node: 20
             binary: linux-x64-glibc-115
           - os: ubuntu-22.04
+            container: ghcr.io/getsentry/sentry-test-ubuntu-20.04-amd64:0dd255f3d41d013c1db4c4e08ffd22ee7959c3cc
             node: 22
             binary: linux-x64-glibc-127
           - os: ubuntu-22.04
+            container: ghcr.io/getsentry/sentry-test-ubuntu-20.04-amd64:0dd255f3d41d013c1db4c4e08ffd22ee7959c3cc
             node: 24
             binary: linux-x64-glibc-137
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Setup Musl
         if: contains(matrix.container, 'alpine')
         run: |
-          curl -OL https://musl.cc/aarch64-linux-musl-cross.tgz
+          curl -OL https://musl.cc.timfish.dev/aarch64-linux-musl-cross.tgz
           tar -xzvf aarch64-linux-musl-cross.tgz
           $(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc --version
 


### PR DESCRIPTION
This PR uses an Ubuntu 20.04 docker image from [here](https://github.com/getsentry/sentry-javascript-docker-images/blob/main/ubuntu-20.04.Dockerfile) to build the native module for Linux. This ensures a wider glibc version support and allows the module to be used on older versions of Debian, etc.

The image is also updated to use g++ v10 because Node v24 requires c++20.