### PR TITLE
ci: `macos-13` deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,19 +109,19 @@ jobs:
             binary: linux-arm64-musl-137
 
             # macos x64
-          - os: macos-15
+          - os: macos-15-intel
             node: 18
             arch: x64
             binary: darwin-x64-108
-          - os: macos-15
+          - os: macos-15-intel
             node: 20
             arch: x64
             binary: darwin-x64-115
-          - os: macos-15
+          - os: macos-15-intel
             node: 22
             arch: x64
             binary: darwin-x64-127
-          - os: macos-15
+          - os: macos-15-intel
             node: 24
             arch: x64
             binary: darwin-x64-137

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,40 +109,40 @@ jobs:
             binary: linux-arm64-musl-137
 
             # macos x64
-          - os: macos-13
+          - os: macos-15
             node: 18
             arch: x64
             binary: darwin-x64-108
-          - os: macos-13
+          - os: macos-15
             node: 20
             arch: x64
             binary: darwin-x64-115
-          - os: macos-13
+          - os: macos-15
             node: 22
             arch: x64
             binary: darwin-x64-127
-          - os: macos-13
+          - os: macos-15
             node: 24
             arch: x64
             binary: darwin-x64-137
 
             # macos arm64
-          - os: macos-13
+          - os: macos-15
             arch: arm64
             node: 18
             target_platform: darwin
             binary: darwin-arm64-108
-          - os: macos-13
+          - os: macos-15
             arch: arm64
             node: 20
             target_platform: darwin
             binary: darwin-arm64-115
-          - os: macos-13
+          - os: macos-15
             arch: arm64
             node: 22
             target_platform: darwin
             binary: darwin-arm64-127
-          - os: macos-13
+          - os: macos-15
             arch: arm64
             node: 24
             target_platform: darwin
@@ -316,7 +316,7 @@ jobs:
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-latest, # macOS arm64
-            macos-13, # macOS x64
+            macos-15-intel, # macOS x64
             windows-latest,
           ]
         node: [18, 20, 22, 24]


### PR DESCRIPTION
macOS 13 is no longer available!