### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
           git config --global --add safe.directory "*"
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         if: ${{ !contains(matrix.container, 'alpine') }}
         id: python-setup
         with:
@@ -263,7 +263,7 @@ jobs:
         run: yarn build:lib
 
       - name: Archive Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: profiling-node-binaries-${{ matrix.binary }}
           path: ${{ github.workspace }}/lib/sentry_cpu_profiler-${{matrix.binary}}.node
@@ -288,7 +288,7 @@ jobs:
         run: yarn build:lib
 
       - name: Extract Prebuilt Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: profiling-node-binaries-*
           path: ${{ github.workspace }}/lib/
@@ -298,7 +298,7 @@ jobs:
         run: yarn build:tarball
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ github.sha }}
           retention-days: 90
@@ -330,7 +330,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines --ignore-scripts --frozen-lockfile
       - name: Download Tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ github.sha }}
       - name: Run tests
@@ -354,7 +354,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines --ignore-scripts --frozen-lockfile
       - name: Download Tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ github.sha }}
       - name: Run tests
@@ -374,7 +374,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-engines --ignore-scripts --frozen-lockfile
       - name: Download Tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ github.sha }}
       - name: Run tests

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   changelog-preview:
-    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@f4889d04564e47311038ecb6b910fef6b6cf1363 # v2
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)