### PR TITLE
fix: integer arithmetic for timestamps, emit elapsed_since_start_ns as string

### DIFF
--- a/bindings/cpu_profiler.cc
+++ b/bindings/cpu_profiler.cc
@@ -566,7 +566,8 @@ napi_value CreateSample(const napi_env &env, const enum ProfileFormat format,
   switch (format) {
   case ProfileFormat::kFormatThread: {
     napi_value timestamp;
-    napi_create_int64(env, sample_timestamp_ns, &timestamp);
+    napi_create_string_utf8(env, std::to_string(sample_timestamp_ns).c_str(),
+                            NAPI_AUTO_LENGTH, &timestamp);
     napi_set_named_property(env, js_node, "elapsed_since_start_ns", timestamp);
   } break;
   case ProfileFormat::kFormatChunk: {
@@ -641,9 +642,8 @@ static void GetSamples(const napi_env &env, const v8::CpuProfile *profile,
     }
 
     uint64_t sample_delta_us = sample_timestamp_us - profile_start_time_us;
-    uint64_t sample_timestamp_ns = sample_delta_us * 1e3;
-    uint64_t sample_offset_from_profile_start_ms =
-        (sample_timestamp_us - profile_start_time_us) * 1e-3;
+    uint64_t sample_timestamp_ns = sample_delta_us * 1000;
+    uint64_t sample_offset_from_profile_start_ms = sample_delta_us / 1000;
     double seconds_since_start =
         (profile_start_timestamp_ms + sample_offset_from_profile_start_ms) *
         1e-3;


### PR DESCRIPTION
Fix integer arithmetic and align ts type