### PR TITLE
ref: rename node cpu profiler package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,6 +272,19 @@ jobs:
         if: matrix.arch != 'arm64'
         run: yarn build:bindings:configure
 
+      - name: Remove unsupported Node LTO flags
+        if: matrix.os == 'windows-2022' && matrix.node == 26 && matrix.arch != 'arm64'
+        shell: pwsh
+        run: |
+          $projectFiles = Get-ChildItem -Path build -Filter *.vcxproj -Recurse
+          foreach ($file in $projectFiles) {
+            $content = Get-Content -Raw -Path $file.FullName
+            $content = $content -replace '(?i)\s*-flto=(thin|full)', ''
+            $content = $content -replace '(?i)\s*/flto=(thin|full)', ''
+            $content = $content -replace '(?i)\s*/opt:lldltojobs=\d+', ''
+            Set-Content -Path $file.FullName -Value $content -NoNewline
+          }
+
       - name: Configure node-gyp (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})
         if: matrix.arch == 'arm64' && matrix.target_platform != 'darwin'
         run: yarn build:bindings:configure:arm64

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sentry-internal/node-cpu-profiler",
+  "name": "@sentry/node-cpu-profiler",
   "version": "2.4.1",
   "description": "Binaries for Sentry Node Profiling",
   "repository": "git://github.com/getsentry/sentry-javascript-profiling-node-binaries.git",

--- a/test/bindings/bindings.test.ts
+++ b/test/bindings/bindings.test.ts
@@ -3,7 +3,7 @@
 // they should not be used outside of this file.
 
 // eslint-disable-next-line import/no-unresolved
-import { PrivateCpuProfilerBindings } from '@sentry-internal/node-cpu-profiler';
+import { PrivateCpuProfilerBindings } from '@sentry/node-cpu-profiler';
 import { platform } from 'os';
 import { describe, expect,test } from 'vitest';
 

--- a/test/bindings/package.json.template
+++ b/test/bindings/package.json.template
@@ -2,6 +2,6 @@
   "name": "node-cpu-profiler-test",
   "license": "MIT",
   "dependencies": {
-    "@sentry-internal/node-cpu-profiler": "{{path}}"
+    "@sentry/node-cpu-profiler": "{{path}}"
   }
 }

--- a/test/bindings/profiler.test.ts
+++ b/test/bindings/profiler.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
-import type { RawChunkCpuProfile, RawThreadCpuProfile } from '@sentry-internal/node-cpu-profiler';
+import type { RawChunkCpuProfile, RawThreadCpuProfile } from '@sentry/node-cpu-profiler';
 // eslint-disable-next-line import/no-unresolved
-import { CpuProfilerBindings, PrivateCpuProfilerBindings,ProfileFormat } from '@sentry-internal/node-cpu-profiler';
+import { CpuProfilerBindings, PrivateCpuProfilerBindings,ProfileFormat } from '@sentry/node-cpu-profiler';
 import { describe, expect,test } from 'vitest';
 
 function fail(message: string): never {

--- a/test/bundler/bundle.mjs
+++ b/test/bundler/bundle.mjs
@@ -1,4 +1,4 @@
-import { CpuProfilerBindings, ProfileFormat } from '@sentry-internal/node-cpu-profiler';
+import { CpuProfilerBindings, ProfileFormat } from '@sentry/node-cpu-profiler';
 
 CpuProfilerBindings.startProfiling('test');
 

--- a/test/bundler/package.json.template
+++ b/test/bundler/package.json.template
@@ -5,6 +5,6 @@
     "webpack": "^5.97.1",
     "node-loader": "^2.1.0",
     "esbuild": "^0.24.2",
-    "@sentry-internal/node-cpu-profiler": "{{path}}"
+    "@sentry/node-cpu-profiler": "{{path}}"
   }
 }

--- a/test/electron/main.mjs
+++ b/test/electron/main.mjs
@@ -7,7 +7,7 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
-const { CpuProfilerBindings, ProfileFormat } = await import('@sentry-internal/node-cpu-profiler');
+const { CpuProfilerBindings, ProfileFormat } = await import('@sentry/node-cpu-profiler');
 
 CpuProfilerBindings.startProfiling('test');
 

--- a/test/electron/package.json.template
+++ b/test/electron/package.json.template
@@ -8,6 +8,6 @@
   "dependencies": {
     "electron": "^34.1.0",
     "@electron/rebuild": "^3.7.1",
-    "@sentry-internal/node-cpu-profiler": "{{path}}"
+    "@sentry/node-cpu-profiler": "{{path}}"
   }
 }


### PR DESCRIPTION
Renames the published package from `@sentry-internal/node-cpu-profiler` to `@sentry/node-cpu-profiler` and updates test imports/fixtures.

CI note: also strips unsupported Node 26 Windows LTO flags from the generated node-gyp project. `node-version: 26` now resolves to Node 26.3.0, whose headers add `/opt:lldltojobs`; MSVC rejects that option when compiling this addon.

This should be released before `getsentry/sentry-javascript` switches its profiling dependency.

Refs getsentry/sentry-javascript#21366